### PR TITLE
Expose InstrumentedObjectStore and make generic over T: ObjectStore

### DIFF
--- a/instrumented-object-store/src/instrumented_object_store.rs
+++ b/instrumented-object-store/src/instrumented_object_store.rs
@@ -42,22 +42,27 @@ pub fn instrument_object_store(
 
 /// A wrapper around an `ObjectStore` that instruments all public methods with tracing.
 #[derive(Clone, Debug)]
-struct InstrumentedObjectStore {
-    inner: Arc<dyn ObjectStore>,
+pub struct InstrumentedObjectStore<T: ObjectStore> {
+    inner: T,
     name: String,
 }
 
-impl InstrumentedObjectStore {
+impl<T: ObjectStore> InstrumentedObjectStore<T> {
     /// Creates a new `InstrumentedObjectStore` wrapping the provided `ObjectStore`.
     ///
     /// # Arguments
     ///
-    /// * `store` - An `Arc`-wrapped `dyn ObjectStore` to be instrumented.
-    pub fn new(store: Arc<dyn ObjectStore>, name: &str) -> Self {
+    /// * `store` - An `ObjectStore` to be instrumented.
+    pub fn new(store: T, name: impl Into<String>) -> Self {
         Self {
             inner: store,
-            name: name.to_owned(),
+            name: name.into(),
         }
+    }
+
+    /// Returns a reference to the inner `ObjectStore`.
+    pub fn inner(&self) -> &T {
+        &self.inner
     }
 }
 
@@ -128,14 +133,14 @@ where
     result
 }
 
-impl Display for InstrumentedObjectStore {
+impl<T: ObjectStore> Display for InstrumentedObjectStore<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         Display::fmt(&self.inner, f)
     }
 }
 
 #[async_trait]
-impl ObjectStore for InstrumentedObjectStore {
+impl<T: ObjectStore> ObjectStore for InstrumentedObjectStore<T> {
     /// Save the provided bytes to the specified location with tracing.
     #[instrument(
         skip_all,

--- a/instrumented-object-store/src/lib.rs
+++ b/instrumented-object-store/src/lib.rs
@@ -60,4 +60,4 @@
 
 mod instrumented_object_store;
 
-pub use instrumented_object_store::instrument_object_store;
+pub use instrumented_object_store::{instrument_object_store, InstrumentedObjectStore};


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

I'd like to consider using `InstrumentedObjectStore` in [`obstore`](https://github.com/developmentseed/obstore), a Python binding to `object_store`. I prototyped this in https://github.com/developmentseed/obstore/pull/544 but I need a few changes to be able to avoid type erasure to use signing APIs.

None of these changes are backwards-incompatible because `InstrumentedObjectStore` isn't currently exposed.

## What changes are included in this PR?

- Expose `InstrumentedObjectStore` publicly. I can't use a generic `Arc<dyn ObjectStore>` because I also expose signing APIs, and those aren't implemented on the type-erased `ObjectStore`. Because they're only implemented on the concrete S3/GCS/Azure stores, I need to store the [non-type-erased `AmazonS3` directly](https://github.com/developmentseed/obstore/blob/aaa92611834a51923fe3e126bb6136ee1a0a50b9/pyo3-object_store/src/aws/store.rs#L66).
- Make `InstrumentedObjectStore` generic over `T: ObjectStore`. As mentioned above, I need to be able to avoid type erasure, so that I can get a reference back to the original `&AmazonS3` to use with signing APIs.
- Expose an `fn inner(&self) -> &T` so that I can access the original store passed in.

## Are these changes tested?

Tested by existing tests.

## Are there any user-facing changes?

Only new APIs.