### PR TITLE
fix: Remove redundant span.in_scope() from execute() setup

### DIFF
--- a/datafusion-tracing/src/instrumented.rs
+++ b/datafusion-tracing/src/instrumented.rs
@@ -359,7 +359,7 @@ impl ExecutionPlan for InstrumentedExec {
     ) -> Result<SendableRecordBatchStream> {
         let span = self.get_span();
 
-        let inner_stream = span.in_scope(|| self.inner.execute(partition, context))?;
+        let inner_stream = self.inner.execute(partition, context)?;
 
         // Wrap the stream with node recording so `datafusion.node` is recorded only after
         // completion, once it is fully qualified.

--- a/tests/snapshots/06_object_store_all_options_trace.snap
+++ b/tests/snapshots/06_object_store_all_options_trace.snap
@@ -114,15 +114,6 @@ expression: json_lines
       },
       {
         "datafusion.boundedness": "Bounded",
-        "datafusion.emission_type": "Final",
-        "datafusion.partitioning": "UnknownPartitioning(1)",
-        "env": "production",
-        "name": "InstrumentedExec",
-        "otel.name": "SortExec",
-        "region": "us-west"
-      },
-      {
-        "datafusion.boundedness": "Bounded",
         "datafusion.emission_type": "Incremental",
         "datafusion.partitioning": "UnknownPartitioning(1)",
         "env": "production",


### PR DESCRIPTION
Span instrumentation is handled by .instrument() during async polling