### PR TITLE
chore: Update to version 53.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Version numbers follow Apache DataFusion releases for compatibility alignment.
 
+## [53.0.1] - 2026-05-06
+
+### Added
+
+- Add support for additional native DataFusion execution metrics, including
+  `output_bytes`
+
+### Fixed
+
+- Close rule phase spans correctly after fatal analyzer, logical optimizer, and
+  physical optimizer rule errors
+
 ## [53.0.0] - 2026-03-25
 
 ### Changed
@@ -129,6 +141,7 @@ Initial public release of DataFusion Tracing.
 - Preview formatting utilities (`pretty_format_compact_batch`)
 - Integration with Jaeger, DataDog, and other OpenTelemetry-compatible collectors
 
+[53.0.1]: https://github.com/datafusion-contrib/datafusion-tracing/compare/53.0.0...53.0.1
 [53.0.0]: https://github.com/datafusion-contrib/datafusion-tracing/compare/52.0.0...53.0.0
 [52.0.0]: https://github.com/datafusion-contrib/datafusion-tracing/compare/51.0.0...52.0.0
 [51.0.0]: https://github.com/datafusion-contrib/datafusion-tracing/compare/50.0.2...51.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-tracing"
-version = "53.0.0"
+version = "53.0.1"
 dependencies = [
  "async-trait",
  "comfy-table",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-tracing-examples"
-version = "53.0.0"
+version = "53.0.1"
 dependencies = [
  "datafusion",
  "integration-utils",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-tracing-tests"
-version = "53.0.0"
+version = "53.0.1"
 dependencies = [
  "datafusion",
  "insta",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "instrumented-object-store"
-version = "53.0.0"
+version = "53.0.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1852,7 +1852,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integration-utils"
-version = "53.0.0"
+version = "53.0.1"
 dependencies = [
  "async-trait",
  "datafusion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 
 [workspace.package]
 description = "DataFusion tracing of execution plans"
-version = "53.0.0"
+version = "53.0.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/datafusion-contrib/datafusion-tracing"
@@ -39,9 +39,9 @@ rust-version = "1.88.0"
 [workspace.dependencies]
 async-trait = "0.1"
 datafusion = { version = "53.0.0", default-features = false }
-datafusion-tracing = { path = "datafusion-tracing", version = "53.0.0" }
+datafusion-tracing = { path = "datafusion-tracing", version = "53.0.1" }
 futures = "0.3"
-instrumented-object-store = { path = "instrumented-object-store", version = "53.0.0" }
+instrumented-object-store = { path = "instrumented-object-store", version = "53.0.1" }
 tokio = { version = "1.48" }
 tracing = { version = "0.1" }
 tracing-futures = { version = "0.2", features = ["futures-03"] }


### PR DESCRIPTION
## Which issue does this PR close?

- None.

## Rationale for this change

This prepares the DataFusion Tracing 53.0.1 patch release. The release stays aligned with Apache DataFusion 53.0.0 while publishing the fixes and additive telemetry support merged after 53.0.0.

## What changes are included in this PR?

- Bump workspace package and internal path dependency versions to `53.0.1`.
- Refresh `Cargo.lock` workspace package versions.
- Add changelog entries for rule phase span cleanup on fatal rule errors.
- Add changelog coverage for additional native DataFusion execution metrics, including `output_bytes`.
- Keep README and rustdoc dependency snippets at `53.0.0`, since Cargo caret requirements resolve compatible patch releases such as `53.0.1` automatically.

## What should reviewers pay particular attention to?

- `Cargo.toml` and `Cargo.lock`:
  This is a patch release only. The Apache DataFusion dependency remains at `53.0.0`, and the diff only updates this workspace package version and internal path dependency constraints.
- `CHANGELOG.md`:
  The new entry summarizes the fixes from the recent rule instrumentation cleanup and the additive metrics field support.
- Public API compatibility:
  This release does not intentionally change public Rust APIs. The user-visible changes are corrected tracing behavior for failed planning paths and additional metric fields when those metrics are present.

## Are these changes tested?

- `cargo check --workspace --all-targets --locked`

## Are there any user-facing changes?

- The crate version is now `53.0.1`.
- Traces can include additional native DataFusion execution metrics such as `datafusion.metrics.output_bytes`.
- Rule phase spans are closed correctly after fatal analyzer, logical optimizer, and physical optimizer rule errors.
- No DataFusion dependency, MSRV, or public API change is included in this patch release.
