### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
       prefix: "chore"
       include: "scope"
   
-  # Note: The hardcoded hawkeye_version and taplo_version in .github/workflows/ci.yml
+  # Note: The hardcoded Taplo and cargo-rdme versions in .github/workflows/ci.yml
   # cannot be automatically updated by Dependabot and will need manual updates.
 
   # Rust dependencies in Cargo.toml files

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
       prefix: "chore"
       include: "scope"
   
-  # Note: The hardcoded Taplo and cargo-rdme versions in .github/workflows/ci.yml
+  # Note: The hardcoded HawkEye, Taplo, and cargo-rdme versions in .github/workflows/ci.yml
   # cannot be automatically updated by Dependabot and will need manual updates.
 
   # Rust dependencies in Cargo.toml files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  HAWKEYE_VERSION: "6.0.3"
   TAPLO_VERSION:  "0.8.1"
   RDME_VERSION:  "1.4.8"
   TPCHGEN_VERSION: "2.0.0"
@@ -49,7 +48,7 @@ jobs:
     - name: Install dev tools (cached after first run)
       run: |
         cargo install --locked taplo-cli@${{ env.TAPLO_VERSION }}
-        cargo install --locked hawkeye@${{ env.HAWKEYE_VERSION }}
+        cargo install --locked hawkeye
         cargo install --locked cargo-rdme@${{ env.RDME_VERSION }}
 
     - run: ./ci/scripts/hawkeye_fmt.sh      # license headers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  HAWKEYE_VERSION: "7.0.0"
+  HAWKEYE_VERSION: "7.0.1"
   TAPLO_VERSION:  "0.8.1"
   RDME_VERSION:  "1.4.8"
   TPCHGEN_VERSION: "2.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  HAWKEYE_VERSION: "7.0.0"
   TAPLO_VERSION:  "0.8.1"
   RDME_VERSION:  "1.4.8"
   TPCHGEN_VERSION: "2.0.0"
@@ -48,7 +49,7 @@ jobs:
     - name: Install dev tools (cached after first run)
       run: |
         cargo install --locked taplo-cli@${{ env.TAPLO_VERSION }}
-        cargo install --locked hawkeye
+        cargo install --locked hawkeye@${{ env.HAWKEYE_VERSION }}
         cargo install --locked cargo-rdme@${{ env.RDME_VERSION }}
 
     - run: ./ci/scripts/hawkeye_fmt.sh      # license headers

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -17,8 +17,10 @@
 #
 # This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2025 Datadog, Inc.
 
-headerPath = "ci/license/header.txt"
+[header]
+path = "ci/license/header.txt"
 
+[files]
 includes = [
     "*.rs",
     "*.py",


### PR DESCRIPTION
## Which issue does this PR close?

N/A — this is a maintenance migration for the license-header tooling.

## Rationale for this change

The existing HawkEye version and configuration target v6 and are incompatible with the latest v7 release.

## What changes are included in this PR?

- migrate the configuration to v7
- pin the HawkEye CI installation to version 7.0.1
- keep the Dependabot note aligned with the manually pinned CI tool versions

## Are these changes tested?

Yes. HawkEye v7.0.1 validates 42 files with 0 changes, 0 conflicts, and 0 unsupported files. Changed YAML and TOML files also pass syntax validation.

## Are there any user-facing changes?

No.
