### PR TITLE
fix(instrumented_exec): delegate order preservation

### DIFF
--- a/datafusion-tracing/src/instrumented_exec.rs
+++ b/datafusion-tracing/src/instrumented_exec.rs
@@ -248,6 +248,7 @@ impl InstrumentedExec {
     }
 }
 
+#[warn(clippy::missing_trait_methods)]
 impl ExecutionPlan for InstrumentedExec {
     // Most ExecutionPlan methods are delegated to the inner plan. Methods that must return a
     // wrapped plan or provide custom behavior are implemented manually below.

--- a/datafusion-tracing/src/instrumented_exec.rs
+++ b/datafusion-tracing/src/instrumented_exec.rs
@@ -306,6 +306,17 @@ impl ExecutionPlan for InstrumentedExec {
         }
     }
 
+    /// Delegate order-preservation requirements to the inner plan and rewrap with
+    /// an InstrumentedExec.
+    fn with_preserve_order(
+        &self,
+        preserve_order: bool,
+    ) -> Option<Arc<dyn ExecutionPlan>> {
+        self.inner
+            .with_preserve_order(preserve_order)
+            .map(|new_inner| self.with_new_inner(new_inner))
+    }
+
     /// Delegate to the inner plan for swapping with a projection and rewrap with an InstrumentedExec.
     fn try_swapping_with_projection(
         &self,


### PR DESCRIPTION
## Summary

- delegate `ExecutionPlan::with_preserve_order` to the wrapped execution plan
- rewrap the updated plan so tracing instrumentation remains installed
- restore the impl-local `clippy::missing_trait_methods` guard to catch future defaulted `ExecutionPlan` methods

## Context

`InstrumentedExec` already delegates `with_fetch`, but it inherited the default `with_preserve_order` implementation, which returns `None`. DataFusion limit pushdown calls these methods in sequence, so callers or optimizer rules operating on an instrumented plan could silently fail to propagate an order-sensitivity requirement to the underlying source.

This gap predates DataFusion 55 and was found while reviewing #61. Registering the instrumentation rule last normally prevents the built-in optimizer from encountering it, but the wrapper should remain transparent for direct callers and any later optimizer rules.

The trait-coverage lint previously protected this wrapper but was removed in [PR #41](https://github.com/datafusion-contrib/datafusion-tracing/pull/41) during the DataFusion 52 work. Restoring it makes future DataFusion trait additions fail CI until their wrapper behavior is considered explicitly.

## Testing

- `cargo test --workspace --all-targets --locked`
- `cargo clippy -p datafusion-tracing --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`